### PR TITLE
fix: updated BR country mask

### DIFF
--- a/src/PhoneInput/constants.ts
+++ b/src/PhoneInput/constants.ts
@@ -329,6 +329,7 @@ export const MASK_PER_COUNTRY: Partial<{
     /\d/,
     /\d/,
     /\d/,
+    /\d/,
     '-',
     /\d/,
     /\d/,


### PR DESCRIPTION
Nowadays almost everyone uses a 9-digit phone number.