### PR TITLE
feat: replace keyboard on iPad with phone number keypad

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -25,6 +25,7 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": ["../plugin/build/index.js"]
   }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -12,6 +12,9 @@ import {
   type CallingCode,
   type CountryCode,
 } from 'react-native-phone-entry';
+import { configureIPadPhonePad } from 'react-native-phone-entry';
+
+configureIPadPhonePad(); // no-op on iPhone, Android, or web
 
 export default function App() {
   const [phoneNumber, setPhoneNumber] = useState('');

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
       }
     }
   },
+  "plugin": "./plugin/build/index.js",
   "files": [
     "lib",
+    "plugin/build",
+    "plugin/ios",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
@@ -32,8 +35,9 @@
     "test:coverage": "jest --collectCoverage --coverageDirectory=\"./coverage\"",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "clean": "del-cli lib",
-    "prepare": "bob build",
+    "clean": "del-cli lib plugin/build",
+    "build:plugin": "tsc -p plugin/tsconfig.json",
+    "prepare": "bob build && yarn build:plugin",
     "release": "release-it"
   },
   "keywords": [
@@ -57,6 +61,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
+    "@expo/config-plugins": "^8.0.0",
     "@react-native/eslint-config": "^0.73.1",
     "@release-it/conventional-changelog": "latest",
     "@swc/core": "^1.10.12",
@@ -67,6 +72,7 @@
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
     "@types/react-test-renderer": "^19.0.0",
+    "@types/xcode": "^3.0.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "commitlint": "^17.0.2",
     "del-cli": "^5.1.0",
@@ -94,8 +100,18 @@
     "react-native-country-picker-modal@^2.0.0": "patch:react-native-country-picker-modal@patch%3Areact-native-country-picker-modal@npm%253A2.0.0%23./.yarn/patches/react-native-country-picker-modal-npm-2.0.0-ffda15a759.patch%3A%3Aversion=2.0.0&hash=4dbe83&locator=react-native-phone-entry%2540workspace%253A.#./.yarn/patches/react-native-country-picker-modal-patch-ff4072ee06.patch"
   },
   "peerDependencies": {
+    "@expo/config-plugins": ">=7.0.0",
+    "expo": ">=50.0.0",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+      "optional": true
+    },
+    "expo": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"

--- a/plugin/ios/PhonePadInputView.swift
+++ b/plugin/ios/PhonePadInputView.swift
@@ -1,0 +1,242 @@
+import UIKit
+
+/// A custom phone-pad input view designed for iPad.
+/// Replaces the system keyboard with a 12-key dial-pad that mirrors the
+/// iPhone phone-pad layout, ensuring a consistent experience across devices.
+@objc public class PhonePadInputView: UIInputView {
+
+  // MARK: - Types
+
+  private struct Key {
+    let primary: String
+    let secondary: String?
+    let action: Action
+
+    enum Action {
+      case insert(String)
+      case delete
+      case openCountryPicker
+      case none
+    }
+
+    init(_ primary: String, _ secondary: String? = nil, action: Action? = nil) {
+      self.primary = primary
+      self.secondary = secondary
+      self.action = action ?? .insert(primary)
+    }
+  }
+
+  // MARK: - Layout
+
+  private let rows: [[Key]] = [
+    [Key("1"), Key("2", "ABC"), Key("3", "DEF")],
+    [Key("4", "GHI"), Key("5", "JKL"), Key("6", "MNO")],
+    [Key("7", "PQRS"), Key("8", "TUV"), Key("9", "WXYZ")],
+    [Key("🌐", action: .openCountryPicker), Key("0", "+"), Key("⌫", action: .delete)],
+  ]
+
+  // MARK: - Properties
+
+  private weak var targetField: UITextField?
+  @objc var onCountryPickerRequest: (() -> Void)?
+
+  // MARK: - Colours (adaptive for dark/light mode)
+
+  private var keyboardBackground: UIColor {
+    UIColor { traits in
+      traits.userInterfaceStyle == .dark
+        ? UIColor(red: 0.17, green: 0.17, blue: 0.18, alpha: 1)
+        : UIColor(red: 0.82, green: 0.84, blue: 0.87, alpha: 1)
+    }
+  }
+
+  private var keyBackground: UIColor {
+    UIColor { traits in
+      traits.userInterfaceStyle == .dark
+        ? UIColor(red: 0.36, green: 0.36, blue: 0.38, alpha: 1)
+        : UIColor.white
+    }
+  }
+
+  private var emptyKeyBackground: UIColor {
+    UIColor { traits in
+      traits.userInterfaceStyle == .dark
+        ? UIColor(red: 0.22, green: 0.22, blue: 0.23, alpha: 1)
+        : UIColor(red: 0.69, green: 0.71, blue: 0.74, alpha: 1)
+    }
+  }
+
+  private var primaryTextColor: UIColor { .label }
+  private var secondaryTextColor: UIColor { .secondaryLabel }
+
+  // MARK: - Init
+
+  @objc public init(textField: UITextField) {
+    self.targetField = textField
+    let screenWidth = UIScreen.main.bounds.width
+    super.init(frame: CGRect(x: 0, y: 0, width: screenWidth, height: 280),
+               inputViewStyle: .keyboard)
+    translatesAutoresizingMaskIntoConstraints = false
+    setupUI()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - UI Setup
+
+  private func setupUI() {
+    backgroundColor = keyboardBackground
+
+    let outerStack = UIStackView()
+    outerStack.axis = .vertical
+    outerStack.distribution = .fillEqually
+    outerStack.spacing = 10
+    outerStack.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(outerStack)
+
+    NSLayoutConstraint.activate([
+      outerStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+      outerStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
+      outerStack.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+      outerStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -6),
+    ])
+
+    for (rowIndex, row) in rows.enumerated() {
+      let rowStack = UIStackView()
+      rowStack.axis = .horizontal
+      rowStack.distribution = .fillEqually
+      rowStack.spacing = 10
+      outerStack.addArrangedSubview(rowStack)
+
+      for key in row {
+        rowStack.addArrangedSubview(makeKeyView(key: key, rowIndex: rowIndex))
+      }
+    }
+  }
+
+  private func makeKeyView(key: Key, rowIndex: Int) -> UIView {
+    // Empty / spacer slot
+    if case .none = key.action {
+      let spacer = UIView()
+      spacer.backgroundColor = emptyKeyBackground
+      spacer.layer.cornerRadius = 5
+      spacer.layer.shadowColor = UIColor.black.cgColor
+      spacer.layer.shadowOpacity = 0.3
+      spacer.layer.shadowOffset = CGSize(width: 0, height: 1)
+      spacer.layer.shadowRadius = 0
+      return spacer
+    }
+
+    let button = UIButton(type: .custom)
+    button.backgroundColor = keyBackground
+    button.layer.cornerRadius = 5
+    button.layer.shadowColor = UIColor.black.cgColor
+    button.layer.shadowOpacity = 0.3
+    button.layer.shadowOffset = CGSize(width: 0, height: 1)
+    button.layer.shadowRadius = 0
+
+    // Store action
+    button.accessibilityLabel = key.primary
+    switch key.action {
+    case .delete:
+      button.addTarget(self, action: #selector(deletePressed(_:)), for: .touchUpInside)
+      addHighlightBehavior(to: button)
+      let img = UIImage(systemName: "delete.left")
+      button.setImage(img, for: .normal)
+      button.tintColor = primaryTextColor
+    case .openCountryPicker:
+      button.addTarget(self, action: #selector(countryPickerPressed), for: .touchUpInside)
+      addHighlightBehavior(to: button)
+      let img = UIImage(systemName: "globe")
+      button.setImage(img, for: .normal)
+      button.tintColor = primaryTextColor
+    case .insert(let char):
+      button.tag = Int(char.unicodeScalars.first?.value ?? 0)
+      button.addTarget(self, action: #selector(keyPressed(_:)), for: .touchUpInside)
+      addHighlightBehavior(to: button)
+      addKeyLabels(to: button, primary: key.primary, secondary: key.secondary)
+    case .none:
+      break
+    }
+
+    return button
+  }
+
+  private func addKeyLabels(to button: UIButton, primary: String, secondary: String?) {
+    let primaryLabel = UILabel()
+    primaryLabel.text = primary
+    primaryLabel.font = UIFont.systemFont(ofSize: 26, weight: .light)
+    primaryLabel.textColor = primaryTextColor
+    primaryLabel.textAlignment = .center
+    primaryLabel.translatesAutoresizingMaskIntoConstraints = false
+    button.addSubview(primaryLabel)
+
+    if let sec = secondary {
+      let secLabel = UILabel()
+      secLabel.text = sec
+      secLabel.font = UIFont.systemFont(ofSize: 10, weight: .medium)
+      secLabel.textColor = secondaryTextColor
+      secLabel.textAlignment = .center
+      secLabel.translatesAutoresizingMaskIntoConstraints = false
+      button.addSubview(secLabel)
+
+      NSLayoutConstraint.activate([
+        primaryLabel.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+        primaryLabel.centerYAnchor.constraint(equalTo: button.centerYAnchor, constant: -7),
+        secLabel.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+        secLabel.topAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: 1),
+      ])
+    } else {
+      NSLayoutConstraint.activate([
+        primaryLabel.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+        primaryLabel.centerYAnchor.constraint(equalTo: button.centerYAnchor),
+      ])
+    }
+  }
+
+  // MARK: - Button Highlight
+
+  private func addHighlightBehavior(to button: UIButton) {
+    button.addTarget(self, action: #selector(buttonHighlighted(_:)), for: .touchDown)
+    button.addTarget(self, action: #selector(buttonHighlighted(_:)), for: .touchDragEnter)
+    button.addTarget(self, action: #selector(buttonUnhighlighted(_:)), for: .touchUpInside)
+    button.addTarget(self, action: #selector(buttonUnhighlighted(_:)), for: .touchDragExit)
+    button.addTarget(self, action: #selector(buttonUnhighlighted(_:)), for: .touchCancel)
+  }
+
+  @objc private func buttonHighlighted(_ sender: UIButton) {
+    sender.alpha = 0.5
+  }
+
+  @objc private func buttonUnhighlighted(_ sender: UIButton) {
+    UIView.animate(withDuration: 0.1) { sender.alpha = 1.0 }
+  }
+
+  // MARK: - Actions
+
+  @objc private func keyPressed(_ sender: UIButton) {
+    guard let scalar = Unicode.Scalar(sender.tag),
+          let field = targetField else { return }
+    let char = String(scalar)
+    // Use insertText so the cursor position and delegate callbacks work correctly
+    field.insertText(char)
+    provideFeedback()
+  }
+
+  @objc private func countryPickerPressed() {
+    provideFeedback()
+    onCountryPickerRequest?()
+  }
+
+  @objc private func deletePressed(_ sender: UIButton) {
+    targetField?.deleteBackward()
+    provideFeedback()
+  }
+
+  private func provideFeedback() {
+    let generator = UIImpactFeedbackGenerator(style: .light)
+    generator.impactOccurred()
+  }
+}

--- a/plugin/ios/RNPhonePadKeyboard.m
+++ b/plugin/ios/RNPhonePadKeyboard.m
@@ -1,0 +1,66 @@
+// NOTE: __RN_PROJECT_NAME__ is substituted by the react-native-phone-entry
+// Expo config plugin at prebuild time (e.g. "MyApp-Swift.h"), giving this
+// Objective-C file access to PhonePadInputView (a Swift class).
+#import <UIKit/UIKit.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
+#import "__RN_PROJECT_NAME__-Swift.h"
+
+@interface RNPhonePadKeyboard : RCTEventEmitter <RCTBridgeModule>
+@end
+
+@implementation RNPhonePadKeyboard {
+  id _observer;
+}
+
+RCT_EXPORT_MODULE()
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[@"onCountryPickerRequested"];
+}
+
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
+- (void)dealloc {
+  if (_observer) {
+    [[NSNotificationCenter defaultCenter] removeObserver:_observer];
+  }
+}
+
+RCT_EXPORT_METHOD(configure) {
+  if (_observer != nil) return;
+
+  __weak typeof(self) weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __strong typeof(self) strongSelf = weakSelf;
+    if (!strongSelf) return;
+    strongSelf->_observer = [[NSNotificationCenter defaultCenter]
+      addObserverForName:UITextFieldTextDidBeginEditingNotification
+      object:nil
+      queue:[NSOperationQueue mainQueue]
+      usingBlock:^(NSNotification *notification) {
+        [weakSelf handleTextFieldFocus:notification];
+      }];
+  });
+}
+
+- (void)handleTextFieldFocus:(NSNotification *)notification {
+  if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPad) return;
+
+  UITextField *field = notification.object;
+  if (![field isKindOfClass:[UITextField class]]) return;
+  if (field.keyboardType != UIKeyboardTypePhonePad) return;
+  if ([field.inputView isKindOfClass:[PhonePadInputView class]]) return;
+
+  __weak typeof(self) weakSelf = self;
+  PhonePadInputView *pad = [[PhonePadInputView alloc] initWithTextField:field];
+  pad.onCountryPickerRequest = ^{
+    [weakSelf sendEventWithName:@"onCountryPickerRequested" body:@{}];
+  };
+  field.inputView = pad;
+  [field reloadInputViews];
+}
+
+@end

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,0 +1,119 @@
+import { createRunOncePlugin, withDangerousMod } from '@expo/config-plugins';
+import type { ConfigPlugin } from '@expo/config-plugins';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Swift file copied verbatim; ObjC file is treated as a template.
+const IOS_SWIFT_FILES = ['PhonePadInputView.swift'];
+const IOS_OBJC_TEMPLATE = 'RNPhonePadKeyboard.m';
+
+// Path to our bundled iOS sources relative to the built plugin (plugin/build/index.js).
+const IOS_SOURCE_DIR = path.join(__dirname, '..', 'ios');
+
+/**
+ * Expo config plugin — adds the iPhone-style phone-pad keyboard for iPads.
+ *
+ * Usage in app.json / app.config.js:
+ *   { "plugins": ["react-native-phone-entry"] }
+ *
+ * Then call `configureIPadPhonePad()` once at app startup (e.g. in App.tsx).
+ */
+const withIPadPhonePad: ConfigPlugin = (config) => {
+  config = withDangerousMod(config, [
+    'ios',
+    (modConfig) => {
+      const projectName = modConfig.modRequest.projectName!;
+      const platformRoot = modConfig.modRequest.platformProjectRoot;
+
+      // withDangerousMod runs AFTER Expo has generated the native project,
+      // so the ios/<AppName>/ directory is guaranteed to exist here.
+      const destDir = path.join(platformRoot, projectName);
+      if (!fs.existsSync(destDir)) {
+        fs.mkdirSync(destDir, { recursive: true });
+      }
+
+      // 1a. Copy Swift files verbatim.
+      for (const file of IOS_SWIFT_FILES) {
+        const src = path.join(IOS_SOURCE_DIR, file);
+        if (!fs.existsSync(src)) {
+          throw new Error(
+            `react-native-phone-entry plugin: missing iOS source file: ${src}`
+          );
+        }
+        fs.copyFileSync(src, path.join(destDir, file));
+      }
+
+      // 1b. Copy the ObjC module file, substituting __RN_PROJECT_NAME__ so the
+      //     file can import the Xcode-generated "<ProjectName>-Swift.h" header
+      //     which exposes PhonePadInputView to Objective-C.
+      const objcTemplateSrc = path.join(IOS_SOURCE_DIR, IOS_OBJC_TEMPLATE);
+      if (!fs.existsSync(objcTemplateSrc)) {
+        throw new Error(
+          `react-native-phone-entry plugin: missing iOS source file: ${objcTemplateSrc}`
+        );
+      }
+      const objcContent = fs
+        .readFileSync(objcTemplateSrc, 'utf8')
+        .replace(/__RN_PROJECT_NAME__/g, projectName);
+      fs.writeFileSync(path.join(destDir, IOS_OBJC_TEMPLATE), objcContent);
+
+      // 2. Register the files in project.pbxproj so Xcode compiles them.
+      //    Done here (not withXcodeProject) to operate on the already-written
+      //    pbxproj, avoiding xcodeproj base-mod timing issues.
+      const xcodeprojs = fs
+        .readdirSync(platformRoot)
+        .filter((name) => name.endsWith('.xcodeproj'));
+
+      if (!xcodeprojs.length) return modConfig;
+
+      const pbxprojPath = path.join(
+        platformRoot,
+        xcodeprojs[0]!,
+        'project.pbxproj'
+      );
+      if (!fs.existsSync(pbxprojPath)) return modConfig;
+
+      // xcode is a peer dep of @expo/config-plugins and is always present.
+
+      const xcode = require('xcode') as typeof import('xcode');
+      const project = xcode.project(pbxprojPath);
+      project.parseSync();
+
+      const firstTarget = project.getFirstTarget();
+      if (!firstTarget) return modConfig;
+
+      // Passing the group key to addSourceFile makes xcode use the addFile()
+      // code path instead of addPluginFile(), which crashes on projects that
+      // have no "Plugins" PBX group (null.path error).
+      const groupKey =
+        project.findPBXGroupKey({ name: projectName }) ??
+        project.findPBXGroupKey({ path: projectName });
+
+      const allFiles = [...IOS_SWIFT_FILES, IOS_OBJC_TEMPLATE];
+      let changed = false;
+      for (const file of allFiles) {
+        const filePath = `${projectName}/${file}`;
+        if (!project.hasFile(filePath)) {
+          project.addSourceFile(
+            filePath,
+            { target: firstTarget.uuid },
+            groupKey
+          );
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        fs.writeFileSync(pbxprojPath, project.writeSync());
+      }
+
+      return modConfig;
+    },
+  ]);
+
+  return config;
+};
+
+const pkg = require('../../package.json');
+
+export default createRunOncePlugin(withIPadPhonePad, pkg.name, pkg.version);

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "lib": ["ES2019"],
+    "strict": true,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "build"]
+}

--- a/src/PhoneInput/PhoneInput.tsx
+++ b/src/PhoneInput/PhoneInput.tsx
@@ -1,5 +1,13 @@
-import React, { useCallback } from 'react';
-import { Appearance, Image, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useRef } from 'react';
+import {
+  Appearance,
+  Image,
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import CountryPicker, {
   CountryModalProvider,
   DARK_THEME,
@@ -22,6 +30,21 @@ export const PhoneInput: React.FC<PhoneInputProps> = (props) => {
     actions: { handleChangeText, onSelect },
     forms: { modalVisible, showModal, hideModal },
   } = usePhoneInput(props);
+
+  // Keep a stable ref so the effect closure never goes stale.
+  const showModalRef = useRef(showModal);
+  showModalRef.current = showModal;
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+    const { RNPhonePadKeyboard } = NativeModules;
+    if (!RNPhonePadKeyboard) return;
+    const emitter = new NativeEventEmitter(RNPhonePadKeyboard);
+    const sub = emitter.addListener('onCountryPickerRequested', () =>
+      showModalRef.current()
+    );
+    return () => sub.remove();
+  }, []);
 
   const {
     theme: {
@@ -104,7 +127,7 @@ export const PhoneInput: React.FC<PhoneInputProps> = (props) => {
           editable={!disabled}
           selectionColor="black"
           keyboardAppearance={enableDarkTheme ? 'dark' : 'default'}
-          keyboardType="number-pad"
+          keyboardType="phone-pad"
           autoFocus={autoFocus}
           {...maskInputProps}
         />

--- a/src/PhonePadKeyboard.ts
+++ b/src/PhonePadKeyboard.ts
@@ -1,0 +1,32 @@
+import { NativeModules, Platform } from 'react-native';
+
+const { RNPhonePadKeyboard } = NativeModules;
+
+/**
+ * Activates the iPhone-style phone-pad keyboard for iPad.
+ *
+ * Call this **once** at app startup (e.g. at the top level of `App.tsx`).
+ * After calling this, any `TextInput` with `keyboardType="phone-pad"` will
+ * show a full 12-key dial-pad on iPad instead of the system floating keyboard.
+ *
+ * On iPhone this is a no-op — the native phone-pad keyboard is already used.
+ *
+ * Requires the Expo config plugin to be added in app.json:
+ *   { "plugins": ["react-native-phone-entry"] }
+ */
+export function configureIPadPhonePad(): void {
+  if (Platform.OS !== 'ios') return;
+
+  if (!RNPhonePadKeyboard) {
+    if (__DEV__) {
+      console.warn(
+        '[react-native-phone-entry] configureIPadPhonePad: native module not found. ' +
+          'Add "react-native-phone-entry" to the plugins array in app.json and run ' +
+          'expo prebuild.'
+      );
+    }
+    return;
+  }
+
+  RNPhonePadKeyboard.configure();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export {
   type CountryCode,
   type PhoneInputProps,
 } from './PhoneInput';
+export { configureIPadPhonePad } from './PhonePadKeyboard';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,6 +2070,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/config-plugins@npm:^8.0.0":
+  version: 8.0.11
+  resolution: "@expo/config-plugins@npm:8.0.11"
+  dependencies:
+    "@expo/config-types": ^51.0.3
+    "@expo/json-file": ~8.3.0
+    "@expo/plist": ^0.1.0
+    "@expo/sdk-runtime-versions": ^1.0.0
+    chalk: ^4.1.2
+    debug: ^4.3.1
+    find-up: ~5.0.0
+    getenv: ^1.0.0
+    glob: 7.1.6
+    resolve-from: ^5.0.0
+    semver: ^7.5.4
+    slash: ^3.0.0
+    slugify: ^1.6.6
+    xcode: ^3.0.1
+    xml2js: 0.6.0
+  checksum: 084b20f6254d28644fbfde13cbf4b155c9d965a7ea44c25e67d1ee8d3675570593e8233291948813c0832e03a26ee600676fe39d78f11e388b62555c537d8463
+  languageName: node
+  linkType: hard
+
 "@expo/config-plugins@npm:~9.0.14":
   version: 9.0.14
   resolution: "@expo/config-plugins@npm:9.0.14"
@@ -2089,6 +2112,13 @@ __metadata:
     xcode: ^3.0.1
     xml2js: 0.6.0
   checksum: d411b2a8ab1602318e02c9ef8c1710b63373d4eedbcba07c29843140c454ee83343fbc82c38a54e0e2ccfc5a6c20234b749fbb62f02178bf0275a037adc23b3b
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^51.0.3":
+  version: 51.0.3
+  resolution: "@expo/config-types@npm:51.0.3"
+  checksum: c46def814a5e0d6c8358b9767a89f51239f4f1c3b4a5305ffcfa1a86e4360ac40de54a65f7c6e787be7656e4144c99a050e98b600a1edd3d6e8e20c83d8e107b
   languageName: node
   linkType: hard
 
@@ -2202,6 +2232,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/json-file@npm:~8.3.0":
+  version: 8.3.3
+  resolution: "@expo/json-file@npm:8.3.3"
+  dependencies:
+    "@babel/code-frame": ~7.10.4
+    json5: ^2.2.2
+    write-file-atomic: ^2.3.0
+  checksum: 49fcb3581ac21c1c223459f32e9e931149b56a7587318f666303a62e719e3d0f122ff56a60d47ee31fac937c297a66400a00fcee63a17bebbf4b8cd30c5138c1
+  languageName: node
+  linkType: hard
+
 "@expo/metro-config@npm:0.19.9, @expo/metro-config@npm:~0.19.9":
   version: 0.19.9
   resolution: "@expo/metro-config@npm:0.19.9"
@@ -2264,6 +2305,17 @@ __metadata:
     split: ^1.0.1
     sudo-prompt: 9.1.1
   checksum: 7a5f1d235c2aff12e8668605a84313c9ec498da63bfd3602628eaba38818cfd6735f6b0fd5e5ab86e415367a16a62dc3170b1cb66d3f2582ec10c3e89fb721a0
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.1.0":
+  version: 0.1.3
+  resolution: "@expo/plist@npm:0.1.3"
+  dependencies:
+    "@xmldom/xmldom": ~0.7.7
+    base64-js: ^1.2.3
+    xmlbuilder: ^14.0.0
+  checksum: 8abe78bed4d1849f2cddddd1a238c6fe5c2549a9dee40158224ff70112f31503db3f17a522b6e21f16eea66b5f4b46cc49d22f2b369067d00a88ef6d301a50cd
   languageName: node
   linkType: hard
 
@@ -3674,6 +3726,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
+  languageName: node
+  linkType: hard
+
+"@types/xcode@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/xcode@npm:3.0.0"
+  checksum: 89391be0d27bd5d38d21a6771100c44b74e6237a12ec3906189bcb697f820878280f713795632baee0f0f439d15bbb320a691efb6b73b08721d2e7bfc5230eeb
   languageName: node
   linkType: hard
 
@@ -7134,7 +7193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^5.0.0":
+"find-up@npm:^5.0.0, find-up@npm:~5.0.0":
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
   dependencies:
@@ -7560,6 +7619,20 @@ __metadata:
   dependencies:
     is-glob: ^4.0.3
   checksum: c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
+  languageName: node
+  linkType: hard
+
+"glob@npm:7.1.6":
+  version: 7.1.6
+  resolution: "glob@npm:7.1.6"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 351d549dd90553b87c2d3f90ce11aed9e1093c74130440e7ae0592e11bbcd2ce7f0ebb8ba6bfe63aaf9b62166a7f4c80cb84490ae5d78408bb2572bf7d4ee0a6
   languageName: node
   linkType: hard
 
@@ -9457,7 +9530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.1, json5@npm:^2.2.3":
+"json5@npm:^2.2.1, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -12320,6 +12393,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": ^17.0.2
     "@evilmartians/lefthook": ^1.5.0
+    "@expo/config-plugins": ^8.0.0
     "@react-native/eslint-config": ^0.73.1
     "@release-it/conventional-changelog": latest
     "@swc/core": ^1.10.12
@@ -12330,6 +12404,7 @@ __metadata:
     "@types/jest": ^29.5.5
     "@types/react": ^18.2.44
     "@types/react-test-renderer": ^19.0.0
+    "@types/xcode": ^3.0.0
     babel-plugin-module-resolver: ^5.0.2
     commitlint: ^17.0.2
     del-cli: ^5.1.0
@@ -12349,8 +12424,15 @@ __metadata:
     release-it: ^17.10.0
     typescript: ^5.2.2
   peerDependencies:
+    "@expo/config-plugins": ">=7.0.0"
+    expo: ">=50.0.0"
     react: "*"
     react-native: "*"
+  peerDependenciesMeta:
+    "@expo/config-plugins":
+      optional: true
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Hello looking for your input if you would like this feature but the team I work on needs it.

It changes the layout of the standard keyboard found on IOS to something that is a little easier to click on a big iPad.

## Before
<img width="550" height="221" alt="Screenshot 2026-03-19 at 4 44 15 PM" src="https://github.com/user-attachments/assets/8ab3fa56-d9af-45e8-bbb3-f8352f972c54" />

## After
<img width="560" height="250" alt="Screenshot 2026-03-19 at 4 48 21 PM" src="https://github.com/user-attachments/assets/4306aee2-98c0-408b-a71e-8a5754d1a491" />


Additionally, I have added to the iPad keyboard a quick launch button for picking the country code. 